### PR TITLE
Fix critical error when pppd tries to connect but the FONA is in data mode

### DIFF
--- a/gprs
+++ b/gprs
@@ -20,6 +20,7 @@ ABORT           "+CGATT: 0"
 
 ""              AT
 TIMEOUT         2
+# expect OK - otherwise send +++ without a newline and then expect OK
 OK-+++\c-OK     ATH
 OK              ATE1
 

--- a/gprs
+++ b/gprs
@@ -19,8 +19,8 @@ ABORT           "ERROR"
 ABORT           "+CGATT: 0"
 
 ""              AT
-TIMEOUT         12
-OK              ATH
+TIMEOUT         2
+OK-+++\c-OK     ATH
 OK              ATE1
 
 # +CPIN provides the SIM card PIN


### PR DESCRIPTION
If the FONA is stuck in data mode, the chatscript will repeatedly fail with 12 second waits for the FONA to reply to 'AT'. By sending +++ on failure, it at least gives the FONA a chance to switch between command and data mode a few times before it's back to a consistent state.
